### PR TITLE
Timestamp was 0xNaN if a block was queried by hash

### DIFF
--- a/src/routes/evm/index.ts
+++ b/src/routes/evm/index.ts
@@ -399,27 +399,12 @@ export default async function (fastify: FastifyInstance, opts: TelosEvmConfig) {
 					}
 				}
 			});
-			//Logger.log(`searching action by hash: ${trxHash} got result: \n${JSON.stringify(results?.hits)}`)
 			let blockDelta = results?.hits?.hits[0]?._source;
 			if (!blockDelta) {
 				return null;
 			}
 
-			const timestamp = new Date(blockDelta['@timestamp'] + 'Z').getTime() / 1000;
-			const blockNumberHex = addHexPrefix(blockDelta["@global"].block_num.toString(16));
-            const extraData = addHexPrefix(blockDelta['@blockHash']);
-            const parentHash = addHexPrefix(blockDelta['@evmPrevBlockHash']);
-
-			return Object.assign({}, BLOCK_TEMPLATE, {
-				gasUsed: "0x0",
-				parentHash: parentHash,
-				hash: blockHash,
-				logsBloom: addHexPrefix(new Bloom().bitvector.toString("hex")),
-				number: removeLeftZeros(blockNumberHex),
-				timestamp: removeLeftZeros(timestamp?.toString(16)),
-				transactions: [],
-                extraData: extraData
-			});
+			return await emptyBlockFromDelta(blockDelta);
 		} catch (e) {
 			console.log(e);
 			return null;


### PR DESCRIPTION
As found by user "Gautam Jha" from Telos EVM Dev telegram:
https://t.me/TelosEVMDevs/11688

```
curl https://mainnet15a.telos.net/evm   -X POST   -H "Content-Type: application/json"   --data '{"method":"eth_getBlockByHash","params":["0xd81067c377a0f827b2292a7f6b88291c33171abb26c64c0f8c5e02eaf462eea6",false],"id":1,"jsonrpc":"2.0"}'
```

Is returning: `0xNaN` for timestamp.

This is likely due to this line: https://github.com/telosnetwork/telos-evm-rpc/blob/7533dcb443d28a3e32a43a53459d2c394da0e383/src/routes/evm/index.ts#L408

In this PR I switch to using the function `emptyBlockFromDelta` which is the same used in `eth_getBlockByNumber` handler.