### PR TITLE
Fix latest block number

### DIFF
--- a/src/routes/evm/index.ts
+++ b/src/routes/evm/index.ts
@@ -499,8 +499,12 @@ export default async function (fastify: FastifyInstance, opts: TelosEvmConfig) {
 				.reverse();
 
 			let lastBlockNum: number;
-			if (indices.length > 0) {
-				const index = indices[0]
+			const index = indices[0]
+			if (indices.length > 1) {
+				const docsCount = parseInt(index['docs.count']);
+				const adjustedNum = indexToSuffixNum(index.index);
+				lastBlockNum = (adjustedNum * 1e7) + docsCount - opts.blockNumberDelta - 1;
+			} else {
 				const results = await fastify.elastic.search({
 					index: `${index.index}`,
 					size: 1,


### PR DESCRIPTION
## Description

This PR improves the method for determining the latest block number in Telos EVM RPC. By selecting the first relevant index from filtered indices, it eliminates the need for iteration, enhancing efficiency and system responsiveness.
<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
