### PR TITLE
Just return account.code as new antelope lib gives proper hex format

### DIFF
--- a/src/routes/evm/index.ts
+++ b/src/routes/evm/index.ts
@@ -773,7 +773,7 @@ export default async function (fastify: FastifyInstance, opts: TelosEvmConfig) {
 		try {
 			const account = await fastify.evm.getEthAccount(address.toLowerCase());
 			if (account.code && account.code.length > 0 && account.code !== "0x") {
-				return addHexPrefix(Buffer.from(account.code).toString("hex"));
+				return account.code;
 			} else {
 				return "0x";
 			}


### PR DESCRIPTION
When we changed to the antelope lib the account.code field now is returned with a proper format that does not require loading into a Buffer